### PR TITLE
hk: bump rexml (security), prep 0.5.2

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    timed_lru (0.5.1)
+    timed_lru (0.5.2)
 
 GEM
   remote: http://rubygems.org/
@@ -14,7 +14,8 @@ GEM
     rainbow (3.1.1)
     rake (13.0.6)
     regexp_parser (2.5.0)
-    rexml (3.2.5)
+    rexml (3.2.8)
+      strscan (>= 3.0.9)
     rspec (3.11.0)
       rspec-core (~> 3.11.0)
       rspec-expectations (~> 3.11.0)
@@ -52,6 +53,7 @@ GEM
     rubocop-rspec (2.11.1)
       rubocop (~> 1.19)
     ruby-progressbar (1.11.0)
+    strscan (3.1.0)
     unicode-display_width (2.1.0)
 
 PLATFORMS

--- a/timed_lru.gemspec
+++ b/timed_lru.gemspec
@@ -4,7 +4,7 @@ Gem::Specification.new do |s|
   s.name        = File.basename(__FILE__, '.gemspec')
   s.summary     = 'Timed LRU'
   s.description = 'Thread-safe LRU implementation with (optional) TTL and constant time operations'
-  s.version     = '0.5.1'
+  s.version     = '0.5.2'
 
   s.authors     = ['Black Square Media']
   s.email       = 'info@blacksquaremedia.com'


### PR DESCRIPTION
Replaces https://github.com/bsm/timed_lru/pull/5

TODO

- merge this
- tag version
- publish to rubygems (I cannot)